### PR TITLE
Fix tab components, Update to allow a select to be multple, various icons.

### DIFF
--- a/src/jinja_flowbite/jinja_flowbite/controls/input_label.jinja
+++ b/src/jinja_flowbite/jinja_flowbite/controls/input_label.jinja
@@ -1,5 +1,5 @@
-{% macro render( text="", class="" ) %}
+{% macro render( for="", text="", class="" ) %}
 
-<label class="block font-medium text-gray-900 dark:text-white {{ class }}">{{ text }}</label>
+<label for="{{for}}" class="block font-medium text-gray-900 dark:text-white {{ class }}">{{ text }}</label>
 
 {% endmacro %}

--- a/src/jinja_flowbite/jinja_flowbite/controls/select.jinja
+++ b/src/jinja_flowbite/jinja_flowbite/controls/select.jinja
@@ -1,6 +1,6 @@
-{% macro render(id="", name="", class="", disabled=False, required=False, additional_attribs="") %}
+{% macro render(multiple=false, id="", name="", class="", disabled=False, required=False, additional_attribs="") %}
 
-<select id="{{id}}" name="{{name}}" {% if disabled %} disabled {% endif %} {% if required %} required {% endif %} class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 {{class}}" {{additional_attribs}}>
+<select {% if multiple %} multiple {% endif %} id="{{id}}" name="{{name}}" {% if disabled %} disabled {% endif %} {% if required %} required {% endif %} class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 {{class}}" {{additional_attribs}}>
     {{ caller() }}
 </select>
 

--- a/src/jinja_flowbite/jinja_flowbite/controls/tab.jinja
+++ b/src/jinja_flowbite/jinja_flowbite/controls/tab.jinja
@@ -3,8 +3,10 @@
 <li id="tab_{{id}}" class="me-2" role="presentation">
 
     {% set target_css_classes = "inline-block p-4 border-b-2 rounded-t-lg hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300" %}
+    {% set selected='false' %}
     {% if active %}
         {% set target_css_classes = "inline-block p-4 border-b-2 rounded-t-lg" %}
+        {% set selected='true' %}
     {% endif %}
 
     <button class="{{target_css_classes}}" 
@@ -13,7 +15,7 @@
                 type="button"
                 role="tab"
                 aria-controls="{{id}}"
-                aria-selected="false">{{title}}</button>
+                aria-selected="{{selected}}">{{title}}</button>
     
 </li>
 

--- a/src/jinja_flowbite/jinja_flowbite/controls/tab_control_header.jinja
+++ b/src/jinja_flowbite/jinja_flowbite/controls/tab_control_header.jinja
@@ -1,7 +1,7 @@
 {% macro render(id, tab_control_body_id, class="") %}
 
-<div id="tab_ctrl_{{ id }}" class="text-sm font-medium text-center text-gray-500 border-b border-gray-200 dark:text-gray-400 dark:border-gray-700 {{ class }}"
-    data-tabs-toggle="#{{ tab_content_container_id }}"
+<div id="tab_ctrl_{{ id }}" class="pb-2 text-sm font-medium text-center text-gray-500 border-b border-gray-200 dark:text-gray-400 dark:border-gray-700 {{ class }}"
+    data-tabs-toggle="#{{ tab_control_body_id }}"
     data-tabs-active-classes="text-primary-600 hover:text-primary-600 dark:text-primary-500 dark:hover:text-primary-500 border-primary-600 dark:border-primary-500" 
     data-tabs-inactive-classes="dark:border-transparent text-gray-500 hover:text-gray-600 dark:text-gray-400 border-gray-100 hover:border-gray-300 dark:border-gray-700 dark:hover:text-gray-300"
     role="tablist">

--- a/src/jinja_flowbite/jinja_flowbite/icons/file_copy.jinja
+++ b/src/jinja_flowbite/jinja_flowbite/icons/file_copy.jinja
@@ -1,0 +1,8 @@
+{% macro render(width_css_class="w-6", height_css_class="h-6", class="") %}
+
+<svg class="{{ width_css_class }} {{ height_css_class }} {{ class }}" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+  <path fill-rule="evenodd" d="M18 3a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2h-1V9a4 4 0 0 0-4-4h-3a1.99 1.99 0 0 0-1 .267V5a2 2 0 0 1 2-2h7Z" clip-rule="evenodd"/>
+  <path fill-rule="evenodd" d="M8 7.054V11H4.2a2 2 0 0 1 .281-.432l2.46-2.87A2 2 0 0 1 8 7.054ZM10 7v4a2 2 0 0 1-2 2H4v6a2 2 0 0 0 2 2h7a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3Z" clip-rule="evenodd"/>
+</svg>
+
+{% endmacro %}

--- a/src/jinja_flowbite/jinja_flowbite/icons/file_copy_alt.jinja
+++ b/src/jinja_flowbite/jinja_flowbite/icons/file_copy_alt.jinja
@@ -1,0 +1,8 @@
+{% macro render(width_css_class="w-6", height_css_class="h-6", class="") %}
+
+<svg class="{{ width_css_class }} {{ height_css_class }} {{ class }}" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+  <path fill-rule="evenodd" d="M7 9v6a4 4 0 0 0 4 4h4a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h1v2Z" clip-rule="evenodd"/>
+  <path fill-rule="evenodd" d="M13 3.054V7H9.2a2 2 0 0 1 .281-.432l2.46-2.87A2 2 0 0 1 13 3.054ZM15 3v4a2 2 0 0 1-2 2H9v6a2 2 0 0 0 2 2h7a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2h-3Z" clip-rule="evenodd"/>
+</svg>
+
+{% endmacro %}

--- a/src/jinja_flowbite/jinja_flowbite/icons/search.jinja
+++ b/src/jinja_flowbite/jinja_flowbite/icons/search.jinja
@@ -1,0 +1,7 @@
+{% macro render(width_css_class="w-6", height_css_class="h-6", class="") %}
+
+<svg class="{{ width_css_class }} {{ height_css_class }} {{ class }}" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+    <path stroke="currentColor" stroke-linecap="round" stroke-width="2" d="m21 21-3.5-3.5M17 10a7 7 0 1 1-14 0 7 7 0 0 1 14 0Z"/>
+</svg>
+
+{% endmacro %}


### PR DESCRIPTION
Fixes:
Issue in tab_control_header.jinja where the data-tabs-toggle was not using the render macro parameter: tab_content_container_id.
Issue in tab.jinja where you could not define the default selected tab.

Updates:
Added "for" option for input labels
Added "multiple" option for select.

Add Icons:
file_copy.jinja
file_copy_alt.jinja
search.jinja